### PR TITLE
Prepare for 0.2.0 release under new name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2022-03-08
+- rename project to `solo1-cli`
+- rename CLI to `solo1`
+
 ## [0.1.0] - 2022-03-08
 - fix build @innir
 - UDP simulator is back @stevenwdv

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
-![](https://img.shields.io/pypi/l/solo-python.svg?style=flat) ![](https://img.shields.io/pypi/pyversions/solo-python.svg?style=flat) ![](https://img.shields.io/pypi/v/solo-python.svg) ![](https://img.shields.io/pypi/wheel/solo-python.svg?style=flat)
+![](https://img.shields.io/pypi/l/solo1.svg?style=flat) ![](https://img.shields.io/pypi/pyversions/solo1.svg?style=flat) ![](https://img.shields.io/pypi/v/solo1.svg) ![](https://img.shields.io/pypi/wheel/solo1.svg?style=flat)
 
 # Python tool and library for SoloKeys Solo 1
 
 This CLI is for Solo 1, for the Solo 2 device use [solo2-cli](https://github.com/solokeys/solo2-cli).
+
+v0.1.0 was the last to be named `solo-python`, since v0.2.0 this project is named `solo1-cli` for clarity, and available from PyPI as `solo1`.
+
+The CLI is now called `solo1`, for the time being `solo` will also be removed, but this is deprecated.
 
 ## Getting Started
 We require Python >= 3.6 and corresponding `pip3` command.
 
 We intend to support Linux, Windows and macOS. Other platforms aren't supported by the [FIDO2 library](https://github.com/Yubico/python-fido2) we rely on.
 
-To get started, run `pip3 install solo-python`, this installs both the `solo` library and the `solo` interface.
+To get started, run `pip3 install solo1`, this installs both the `solo1` library and the `solo1` command-line interface.
 
 Possible issues:
 
@@ -20,23 +24,23 @@ For development, we suggest you run `make init` instead, which
 
 - sets up a virtual environment
 - installs development requirements such as `black`
-- installs `solo` as symlink using our packaging tool `flit`, including all runtime dependencies listed in [`pyproject.toml`](pyproject.toml)
+- installs `solo1` as symlink using our packaging tool `flit`, including all runtime dependencies listed in [`pyproject.toml`](pyproject.toml)
 
 One way to ensure the virtual environment is active is to use [direnv](https://direnv.net/).
 
 ## Solo Tool
-For help, run `solo --help` after installation. The tool has a hierarchy of commands and subcommands.
+For help, run `solo1 --help` after installation. The tool has a hierarchy of commands and subcommands.
 
 Example:
 
 ```bash
-solo ls  # lists all Solo keys connected to your machine
-solo version  # outputs version of installed `solo` library and tool
+solo1 ls  # lists all Solo keys connected to your machine
+solo1 version  # outputs version of installed `solo` library and tool
 
-solo key wink  # blinks the LED
-solo key verify  # checks whether your Solo is genuine
-solo key rng hexbytes  # outputs some random hex bytes generated on your key
-solo key version  # outputs the version of the firmware on your key
+solo1 key wink  # blinks the LED
+solo1 key verify  # checks whether your Solo is genuine
+solo1 key rng hexbytes  # outputs some random hex bytes generated on your key
+solo1 key version  # outputs the version of the firmware on your key
 ```
 
 ## Firmware Update
@@ -44,15 +48,15 @@ solo key version  # outputs the version of the firmware on your key
 Upon release of signed firmware updates in [solokeys/solo](https://github.com/solokeys/solo),
 to update the firmware on your Solo to the latest version:
 
-- update your `solo` tool if necessary via `pip3 install --upgrade solo-python`
+- update your `solo1` tool if necessary via `pip3 install --upgrade solo1`
 - plug in your key, keeping the button pressed until the LED flashes yellow
-- run `solo key update`
+- run `solo1 key update`
 
 For possibly helpful additional information, see <https://github.com/solokeys/solo/issues/113>.
 
 ## Library Usage
 
-The previous `solotool.py` has been refactored into a library with associated CLI tool called `solo`.
+The previous `solotool.py` has been refactored into a library with associated CLI tool called `solo1`.
 
 It is still work in progress, example usage:
 
@@ -71,7 +75,7 @@ Comprehensive documentation coming, for now these are the main components
 
 - `solo.client`: connect to Solo Hacker and Solo Secure keys in firmware or bootloader mode
 - `solo.dfu`: connect to Solo Hacker in dfu mode (disabled on Solo Secure keys)
-- `solo.cli`: implementation of the `solo` command line interface
+- `solo.cli`: implementation of the `solo1` command line interface
 
 ## Challenge-Response
 
@@ -91,10 +95,10 @@ if you detect anything.
 
 There are two steps:
 
-1. Generate a credential. This can be done with `solo key make-credential`, storing the
+1. Generate a credential. This can be done with `solo1 key make-credential`, storing the
    (hex-encoded) generated `credential_id` for the next step.
 2. Pick a challenge, and generate the associated response. This can be done with
-   `solo key challenge-response <credential_id> <challenge>`.
+   `solo1 key challenge-response <credential_id> <challenge>`.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,13 @@
-
 [build-system]
 requires = ["flit"]
 build-backend = "flit.buildapi"
 
 [tool.flit.metadata]
 module = "solo"
-dist-name = "solo-python"  # Unfortunately, `solo` is in use on PyPI
+dist-name = "solo1"
 author = "SoloKeys"
 author-email = "hello@solokeys.com"
-home-page = "https://github.com/solokeys/solo-python"
+home-page = "https://github.com/solokeys/solo1-cli"
 requires-python = ">=3.6"
 description-file = "README.md"
 requires = [
@@ -29,7 +28,11 @@ classifiers=[
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
 ]
 
 [tool.flit.scripts]
 solo = "solo.cli:solo_cli"
+solo1 = "solo.cli:solo_cli"

--- a/solo/cli/__init__.py
+++ b/solo/cli/__init__.py
@@ -35,7 +35,7 @@ solo_cli.add_command(program)
 
 @click.command()
 def version():
-    """Version of python-solo library and tool."""
+    """Version of solo1 library and tool."""
     print(solo.__version__)
 
 

--- a/solo/cli/key.py
+++ b/solo/cli/key.py
@@ -183,7 +183,7 @@ def challenge_response(serial, host, user, prompt, credential_id, challenge, udp
     a 32 byte value is expected (in original usage, it's a salt).
 
     This means that we first need to setup a credential_id; this depends on the
-    specific authenticator used. To do this, use `solo key make-credential`.
+    specific authenticator used. To do this, use `solo1 key make-credential`.
 
     If so desired, user and relying party can be changed from the defaults.
 
@@ -385,12 +385,12 @@ def verify(pin, serial, udp):
             print(
                 "Your key's PIN is blocked. To use it again, you need to fully reset it."
             )
-            print("You can do this using: `solo key reset`")
+            print("You can do this using: `solo1 key reset`")
             sys.exit(1)
         # error 0x01
         if "INVALID_COMMAND" in cause:
             print("Error getting credential, is your key in bootloader mode?")
-            print("Try: `solo program aux leave-bootloader`")
+            print("Try: `solo1 program aux leave-bootloader`")
             sys.exit(1)
         raise
 

--- a/solo/cli/program.py
+++ b/solo/cli/program.py
@@ -52,7 +52,7 @@ def dfu(serial, connect_attempts, detach, dry_run, firmware):
     """Program via STMicroelectronics DFU interface.
 
 
-    Enter dfu mode using `solo program aux enter-dfu` first.
+    Enter dfu mode using `solo1 program aux enter-dfu` first.
     """
 
     import time
@@ -159,7 +159,7 @@ def bootloader(serial, firmware):
     match the bootloader's verifying key, you will be stuck in bootloader
     mode until you find a signed firmware that does match.
 
-    Enter bootloader mode using `solo program aux enter-bootloader` first.
+    Enter bootloader mode using `solo1 program aux enter-bootloader` first.
     """
 
     p = solo.client.find(serial)

--- a/solo/cli/update.py
+++ b/solo/cli/update.py
@@ -73,7 +73,7 @@ def update(serial, yes, local_firmware_server, alpha):
     except Exception:
         print()
         print("Unhandled error connecting to key.")
-        print("Please report via https://github.com/solokeys/solo-python/issues/")
+        print("Please report via https://github.com/solokeys/solo1-cli/issues/")
         print()
         sys.exit(1)
 


### PR DESCRIPTION
There has been confusion about whether solo-python supports Solo 2, and whterh solo2-cli supports Solo 1.

Hence, renaming this project, to make clearer its focus on Solo 1, only.

Generally:
- use `solo1` (via `pip install --upgrade solo1`) to update Solo 1 devices and use their specific functionality
- use `solo2` (via `cargo install --force ---locked solo2`) to update Solo2 device and use their specific functionality

For FIDO functionality, this is mostly independent of the device. `solo2` does not have proper support for FIDO yet, as there is no good CTAP-library for Rust yet. So, you can use `solo1` for this (e.g. `solo1 key make-credential`), or general-purpose tools like `fido2-token`.

Following release of `solo1-cli` on PyPI as `solo1`, I will make a final `solo-python` release which depends on the new package and is otherwise empty, following the approach recommended by https://github.com/simonw/pypi-rename.

At least for now, leaving the module `solo` inside this with its old name, to prevent dependees on `solo-python` **as a library** from breaking (:crossed_fingers:).

@conorpp @szszszsz